### PR TITLE
I updated the batch files so they should work more consistently.

### DIFF
--- a/Skins/BuildSkins 360.bat
+++ b/Skins/BuildSkins 360.bat
@@ -1,7 +1,17 @@
-ECHO Building Skin Files 360...
+@ECHO OFF
+ECHO Building Skin Files  (360)...
 
-del ..\..\..\..\Skins\360\*.skin
+REM Project file passes solution directory as first parameter.
+set SKIN_BASE="%1\Skins"
+set SKIN_DIR="%1\Skins\360"
+set Z_DIR="%1\Tools\7zip"
 
-..\..\..\..\Tools\7zip\7za.exe a -tzip -mx9 -r -x!Addons "..\..\..\..\Skins\360\Default.skin" ".\Content\Skins\Default\*.*"
-..\..\..\..\Tools\7zip\7za.exe a -tzip -mx9 -r -x!Addons "..\..\..\..\Skins\360\Green.skin" ".\Content\Skins\Green\*.*"
+ECHO +7ZIP: %Z_DIR%
+ECHO +SKIN: %SKIN_BASE%
+ECHO +PLAT: %SKIN_DIR%
+
+del %SKIN_DIR%\*.skin
+
+%Z_DIR%\7za.exe a -tzip -mx9 -r -x!Addons "%SKIN_DIR%\Default.skin" "%SKIN_BASE%\Content\Skins\Default\*.*"
+%Z_DIR%\7za.exe a -tzip -mx9 -r -x!Addons "%SKIN_DIR%\Green.skin" "%SKIN_BASE%\Content\Skins\Green\*.*"
 

--- a/Skins/BuildSkins.bat
+++ b/Skins/BuildSkins.bat
@@ -1,12 +1,22 @@
-ECHO Building Skin Files...
+@ECHO OFF
+ECHO Building Skin Files  (WIN/XNA)...
 
-del ..\..\Skins\*.skin
+REM Project file passes solution directory as first parameter.
+set SKIN_BASE="%1\Skins"
+set SKIN_DIR="%1\Skins"
+set CONTENT_DIR="%1\Skins\Bin\x86\Content\Skins"
+set Z_DIR="%1\Tools\7zip"
 
-..\..\Tools\7zip\7za.exe a -tzip -mx9 -r -x!Addons "..\..\Skins\Default.skin" ".\Bin\x86\Content\Skins\Default\*.*"
-..\..\Tools\7zip\7za.exe a -tzip -mx9 -r -x!Addons "..\..\Skins\Green.skin" ".\Bin\x86\Content\Skins\Green\*.*"
-..\..\Tools\7zip\7za.exe a -tzip -mx9 -r -x!Addons "..\..\Skins\Blue.skin" ".\Bin\x86\Content\Skins\Blue\*.*"
-..\..\Tools\7zip\7za.exe a -tzip -mx9 -r -x!Addons "..\..\Skins\Magenta.skin" ".\Bin\x86\Content\Skins\Magenta\*.*"
-..\..\Tools\7zip\7za.exe a -tzip -mx9 -r -x!Addons "..\..\Skins\Purple.skin" ".\Bin\x86\Content\Skins\Purple\*.*"
+ECHO +7ZIP: %Z_DIR%
+ECHO +SKIN: %SKIN_BASE%
+ECHO +PLAT: %SKIN_DIR%
+ECHO +CONT: %CONTENT_DIR%
+
+del %SKIN_DIR%\*.skin
+
+SET SKINS=Default,Green,Blue,Magenta,Purple
+
+FOR %%A in (%SKINS%) do "%Z_DIR%\7za.exe" a -tzip -mx9 -r -x!Addons "%SKIN_DIR%\%%A.skin" "%CONTENT_DIR%\%%A\*.*"
 
 
 

--- a/Skins/Skins 360.csproj
+++ b/Skins/Skins 360.csproj
@@ -158,10 +158,10 @@
   -->
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties Reset="0" AssemblyVersion="0" AssemblyFileVersion="0" StartDate="20080911" />
+      <UserProperties StartDate="20080911" AssemblyFileVersion="0" AssemblyVersion="0" Reset="0" />
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>
-    <PreBuildEvent>"..\..\BuildSkins 360.bat"</PreBuildEvent>
+    <PreBuildEvent>"$(SolutionDir)\Skins\BuildSkins 360.bat" "$(SolutionDir)"</PreBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Skins/Skins.csproj
+++ b/Skins/Skins.csproj
@@ -159,11 +159,10 @@
   -->
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties Reset="0" AssemblyVersion="1" AssemblyFileVersion="0" StartDate="20080911" />
+      <UserProperties StartDate="20080911" AssemblyFileVersion="0" AssemblyVersion="1" Reset="0" />
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
+    <PreBuildEvent>"$(SolutionDir)\Skins\BuildSkins.bat" "$(SolutionDir)"</PreBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
On my system (Windows 8 x64), Visual Studio 2010 isn't setting the directory when building the content project.

So what I changed is:
1. In the CSPROJ, use $(SolutionDir) to locate the batch file.  Rather than assuming the directory is correct, take the solution directory as the first parameter.
1. In the batch files, set up some variables first -- then use those rather than ..........\ -- that way, they don't care what directory they are run from.
2.  In the PC batch file, instead of repeating a line five times -- once for each skin -- set up a comma separated variable and use a for loop.
